### PR TITLE
fix: avoid multiple daily reminder timers

### DIFF
--- a/src/utils/reminders.ts
+++ b/src/utils/reminders.ts
@@ -1,6 +1,8 @@
 import { loadSettings } from '@/utils/storageClient';
 import { showLocalNotification } from '@/utils/notifications';
 
+let reminderTimeout: number | null = null;
+
 export function scheduleDailyReminder() {
   try {
     const s = loadSettings() as any;
@@ -14,7 +16,11 @@ export function scheduleDailyReminder() {
     if (next.getTime() <= now.getTime()) next.setDate(next.getDate() + 1);
 
     const delay = Math.max(0, next.getTime() - now.getTime());
-    window.setTimeout(async () => {
+
+    if (reminderTimeout !== null) {
+      window.clearTimeout(reminderTimeout);
+    }
+    reminderTimeout = window.setTimeout(async () => {
       try {
         await showLocalNotification('Time for your focus session — keep your Zen Garden alive!');
       } catch {}


### PR DESCRIPTION
## Summary
- ensure only one daily reminder timeout is active at a time

## Testing
- `npm run lint` *(fails: 90 problems (81 errors, 9 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689ae6711854832ca4756c7b594cbbc4