### PR TITLE
Add locked tile check for garden placement

### DIFF
--- a/src/utils/storageClient.ts
+++ b/src/utils/storageClient.ts
@@ -1,3 +1,5 @@
+import { isTileLocked } from './gardenMap';
+
 export type Task = { id: string; title: string; notes?: string };
 export type ColumnKey = 'now' | 'next' | 'later';
 export type TasksState = Record<ColumnKey, Task[]>;
@@ -210,6 +212,8 @@ export const placeGardenItem = (token: GardenStep, x: number, y: number, rotatio
   const garden = p.garden!;
   // Check bounds
   if (x < 0 || y < 0 || x >= garden.cols || y >= garden.rows) return { ok: false, reason: 'out_of_bounds' } as const;
+  // Check locked tiles
+  if (isTileLocked(x, y)) return { ok: false, reason: 'locked' } as const;
   // Check occupancy
   if (garden.placed.some(it => it.x === x && it.y === y)) return { ok: false, reason: 'occupied' } as const;
 


### PR DESCRIPTION
## Summary
- prevent items from being placed on locked garden tiles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 90 problems, 81 errors)*


------
https://chatgpt.com/codex/tasks/task_e_689ae840c038832c9778ce6208a755cc