### PR TITLE
Fix garden inventory not updating after item placement

### DIFF
--- a/src/pages/Garden.tsx
+++ b/src/pages/Garden.tsx
@@ -236,12 +236,20 @@ export default function Garden() {
               </div>
 
               <div className="space-y-3 animate-fade-in">
-                {(!progress.pendingTokens || progress.pendingTokens.length === 0) && (
+                {(!progress.pendingTokens?.length && !progress.inventory?.length) && (
                   <div className="text-sm text-muted-foreground">You have no items to place.</div>
                 )}
-                {progress.pendingTokens && progress.pendingTokens.map((token, i) => (
-                  <div key={`${token.id}-${i}`} className="flex items-center justify-between p-3 rounded-lg border bg-card">
+                {progress.pendingTokens?.map((token, i) => (
+                  <div key={`pending-${token.id}-${i}`} className="flex items-center justify-between p-3 rounded-lg border bg-card">
                     <div className="flex items-center gap-2"><img src={token.img} alt={token.label} className="w-8 h-8 object-contain"/><div><div className="text-sm font-medium">{token.label}</div><div className="text-xs text-muted-foreground">Pending</div></div></div>
+                    <div className="flex gap-2">
+                      <button className="px-3 py-1.5 rounded-md bg-secondary text-secondary-foreground text-sm hover-scale" onClick={() => openPlaceFor(token)}>Place</button>
+                    </div>
+                  </div>
+                ))}
+                {progress.inventory?.map((token, i) => (
+                  <div key={`inv-${token.id}-${i}`} className="flex items-center justify-between p-3 rounded-lg border bg-card">
+                    <div className="flex items-center gap-2"><img src={token.img} alt={token.label} className="w-8 h-8 object-contain"/><div><div className="text-sm font-medium">{token.label}</div><div className="text-xs text-muted-foreground">Inventory</div></div></div>
                     <div className="flex gap-2">
                       <button className="px-3 py-1.5 rounded-md bg-secondary text-secondary-foreground text-sm hover-scale" onClick={() => openPlaceFor(token)}>Place</button>
                     </div>

--- a/src/utils/gardenHelpers.ts
+++ b/src/utils/gardenHelpers.ts
@@ -14,7 +14,7 @@ export const placeGardenItem = (token: GardenStep, x: number, y: number, rotatio
   // Ensure the user actually owns an unplaced instance of this token
   let consumedSource: 'pendingToken' | 'pendingTokens' | 'inventory' | null = null;
   if (p.pendingToken && p.pendingToken.id === token.id) consumedSource = 'pendingToken';
-  else if (p.pendingTokens && p.pendingTokens.find(t => t.id === token.id)) consumedSource = 'pendingTokens';
+  else if (p.pendingTokens && p.pendingTokens.find(t => t.id === token.id && t.img === token.img)) consumedSource = 'pendingTokens';
   else if (p.inventory && p.inventory.find(t => t.id === token.id && t.img === token.img)) consumedSource = 'inventory';
 
   if (!consumedSource) {
@@ -25,12 +25,14 @@ export const placeGardenItem = (token: GardenStep, x: number, y: number, rotatio
   garden.placed.push({ id, type: 'step', tokenId: token.id, img: token.img, label: token.label, x, y, rotation, placedAt: new Date().toISOString() });
 
   // Consume exactly one from the appropriate source
-  if (consumedSource === 'pendingToken') {
+  if (p.pendingToken && p.pendingToken.id === token.id) {
     p.pendingToken = null;
-  } else if (consumedSource === 'pendingTokens' && p.pendingTokens) {
-    const idx = p.pendingTokens.findIndex(t => t.id === token.id);
+  }
+  if ((consumedSource === 'pendingToken' || consumedSource === 'pendingTokens') && p.pendingTokens) {
+    const idx = p.pendingTokens.findIndex(t => t.id === token.id && t.img === token.img);
     if (idx !== -1) p.pendingTokens.splice(idx, 1);
-  } else if (consumedSource === 'inventory' && p.inventory) {
+  }
+  if (consumedSource === 'inventory' && p.inventory) {
     const idx = p.inventory.findIndex(t => t.id === token.id && t.img === token.img);
     if (idx !== -1) p.inventory.splice(idx, 1);
   }


### PR DESCRIPTION
## Summary
- remove placed tokens from both pendingToken and pendingTokens to prevent duplicate inventory entries
- show stored garden items in the inventory overlay so removed items can be placed again

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 93 problems (84 errors, 9 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689aefe8eaa4832ca613ff609b1ca009