### PR TITLE
feat: limit garden decay notification

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,21 +2,16 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 import { loadProgress, saveProgress } from '@/utils/storageClient'
-import { showLocalNotification } from '@/utils/notifications'
+import { maybeShowGardenDecayNotification } from '@/utils/notifications'
 import { scheduleDailyReminder } from '@/utils/reminders'
 
 const root = createRoot(document.getElementById("root")!);
 root.render(<App />);
 
-// Decay check on open: notify based on previous stage, then mark opened
+// Decay check on open: notify based on previous stage once per day, then mark opened
 try {
   const p = loadProgress();
-  const prevStage = p.decayStage ?? 0;
-  if (prevStage === 1) {
-    showLocalNotification('Your Zen Garden is getting thirsty…', 'Time to focus!');
-  } else if (prevStage === 2) {
-    showLocalNotification('Your garden has withered — revive it by focusing!', 'Complete 3 sessions to revive it.');
-  }
+  maybeShowGardenDecayNotification(p.decayStage ?? 0);
   p.lastOpenedAt = Date.now();
   saveProgress(p);
 } catch {}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -71,16 +71,6 @@ const Index = () => {
     return () => observer.disconnect();
   }, []);
 
-  // Push notifications for decay stages (on open)
-  useEffect(() => {
-    const p = loadProgress();
-    if ((p.decayStage ?? 0) === 1) {
-      showLocalNotification('Your Zen Garden is getting thirsty…', 'Time to focus!');
-    }
-    if ((p.decayStage ?? 0) === 2) {
-      showLocalNotification('Your garden has withered — revive it by focusing!', 'Complete 3 sessions to revive it.');
-    }
-  }, []);
   useEffect(() => {
     if (running) return;
     if (mode === 'fixed') {

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -24,3 +24,24 @@ export async function showLocalNotification(title: string, body?: string) {
     console.warn('Notification error', e);
   }
 }
+
+const DECAY_NOTIF_KEY = 'monk.lastDecayNotif';
+
+/**
+ * Show garden decay warning at most once per 24 hours.
+ */
+export function maybeShowGardenDecayNotification(stage?: 0 | 1 | 2) {
+  try {
+    const now = Date.now();
+    const last = Number(localStorage.getItem(DECAY_NOTIF_KEY) || 0);
+    const dayMs = 24 * 60 * 60 * 1000;
+    if (now - last < dayMs) return;
+    if (stage === 1) {
+      showLocalNotification('Your Zen Garden is getting thirsty…', 'Time to focus!');
+      localStorage.setItem(DECAY_NOTIF_KEY, String(now));
+    } else if (stage === 2) {
+      showLocalNotification('Your garden has withered — revive it by focusing!', 'Complete 3 sessions to revive it.');
+      localStorage.setItem(DECAY_NOTIF_KEY, String(now));
+    }
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- show garden decay notification at most once per day
- hook decay check to new daily notifier
- remove redundant decay notification effect on Index page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: ESLint errors)


------
https://chatgpt.com/codex/tasks/task_e_689af2a03684832c902dfd97b53db39a