### PR TITLE
Add drop shadow to garden, animate legendary glow, and support 2x2 items

### DIFF
--- a/src/components/garden/GardenCanvas.tsx
+++ b/src/components/garden/GardenCanvas.tsx
@@ -46,7 +46,7 @@ export function GardenCanvas({
 
   return (
     <div
-      className={`relative overflow-hidden ${className}`}
+      className={`relative overflow-hidden garden-shadow ${className}`}
       style={{ width: w, height: h }}
     >
       <img
@@ -54,7 +54,7 @@ export function GardenCanvas({
         alt="Zen garden map background"
         width={w}
         height={h}
-        className="pixelated garden-shadow"
+        className="pixelated"
         style={{
           width: w,
           height: h,
@@ -131,12 +131,23 @@ export function GardenCanvas({
           style={{
             left: it.x * TILE_PX,
             top: it.y * TILE_PX,
-            width: TILE_PX,
-            height: TILE_PX,
+            width: (it.w || 1) * TILE_PX,
+            height: (it.h || 1) * TILE_PX,
           }}
           onPointerDown={(e) => onItemPointerDown?.(e, it)}
         >
-          <img src={it.img} alt={it.label || 'Garden item'} width={TILE_PX} height={TILE_PX} style={{ width: TILE_PX, height: TILE_PX, objectFit: 'contain', imageRendering: 'pixelated' as any }} />
+          <img
+            src={it.img}
+            alt={it.label || 'Garden item'}
+            width={(it.w || 1) * TILE_PX}
+            height={(it.h || 1) * TILE_PX}
+            style={{
+              width: (it.w || 1) * TILE_PX,
+              height: (it.h || 1) * TILE_PX,
+              objectFit: 'contain',
+              imageRendering: 'pixelated' as any,
+            }}
+          />
         </div>
       ))}
 

--- a/src/index.css
+++ b/src/index.css
@@ -204,13 +204,6 @@ body.dark .shopify-buy__product__price {
   .path-card { flex-basis: 88px; height: 88px; }
 }
 
-/* Custom animations */
-@keyframes legendary-glow {
-  0% { box-shadow: 0 0 0 hsl(var(--legendary) / 0); }
-  50% { box-shadow: 0 0 28px hsl(var(--legendary) / 0.45), 0 0 64px hsl(var(--legendary) / 0.25); }
-  100% { box-shadow: 0 0 0 hsl(var(--legendary) / 0); }
-}
-
 @layer utilities {
   .pixelated {
     image-rendering: pixelated;
@@ -243,9 +236,20 @@ body.dark .shopify-buy__product__price {
   .garden-shadow {
     filter: drop-shadow(0 16px 28px hsl(var(--ring) / 0.25)) drop-shadow(0 4px 8px hsl(var(--ring) / 0.2));
   }
+  @keyframes legendary-glow {
+    0%, 100% {
+      box-shadow: 0 0 24px hsl(var(--legendary) / 0.4),
+                  0 0 56px hsl(var(--legendary) / 0.2);
+    }
+    50% {
+      box-shadow: 0 0 32px hsl(var(--legendary) / 0.6),
+                  0 0 72px hsl(var(--legendary) / 0.3);
+    }
+  }
+
   .legendary-ring {
     border-radius: 12px;
-    animation: legendary-glow 2.2s ease-in-out infinite;
+    animation: legendary-glow 2s ease-in-out infinite;
   }
 }
 

--- a/src/pages/Garden.tsx
+++ b/src/pages/Garden.tsx
@@ -109,15 +109,12 @@ export default function Garden() {
     const relY = Math.min(Math.max(e.clientY - stageRect.top, 0), stageRect.height);
     const gx = Math.floor(relX / (cellW * scale));
     const gy = Math.floor(relY / (cellH * scale));
-
-    // Check vacancy
-    const occupied = garden.placed.some(it => it.x === gx && it.y === gy && it.id !== id);
-    if (occupied) {
-      alert('That spot is taken.');
-      setProgress(loadProgress());
-      return;
+    const res = moveGardenItem(id, gx, gy);
+    if (!res.ok) {
+      if (res.reason === 'occupied') alert('That spot is taken.');
+      else if (res.reason === 'locked') alert('You cannot place on temple tiles.');
+      else if (res.reason === 'out_of_bounds') alert('Out of bounds.');
     }
-    moveGardenItem(id, gx, gy);
     setProgress(loadProgress());
   };
 

--- a/src/pages/ZenPath.tsx
+++ b/src/pages/ZenPath.tsx
@@ -48,6 +48,7 @@ export default function ZenPath() {
           {Array.from({ length: progress.pathLength }).map((_, index) => {
             const step = progress.currentPath[index];
             const isEmpty = !step;
+            const isLegendary = (step as any)?.rarity === 'legendary';
             
             return (
               <div
@@ -60,10 +61,10 @@ export default function ZenPath() {
               >
                   {step ? (
                     <>
-                      <img 
-                        src={step.img} 
+                      <img
+                        src={step.img}
                         alt={step.label}
-                        className="w-12 h-12 object-contain mb-2"
+                        className={`w-12 h-12 object-contain mb-2 ${isLegendary ? 'legendary-ring p-1' : ''}`}
                         onError={(e) => {
                           // Fallback for missing images
                           e.currentTarget.style.display = 'none';

--- a/src/utils/storageClient.ts
+++ b/src/utils/storageClient.ts
@@ -38,6 +38,8 @@ export type GardenPlacedItem = {
   y: number; // 0-based row
   rotation: 0 | 90 | 180 | 270;
   placedAt: string;
+  w?: number;
+  h?: number;
 };
 
 export type GardenState = {


### PR DESCRIPTION
## Summary
- soften garden background with drop shadow
- show animated legendary glow in path preview and reward reveal
- treat specific garden items as 2x2 tiles with updated placement, movement, and rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 95 problems, 86 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689af70a4930832c94a8bdac59141a84