### PR TITLE
Add drop shadow to garden, animate legendary glow, support 2x2 items, and show placement preview

### DIFF
--- a/src/components/garden/GardenCanvas.tsx
+++ b/src/components/garden/GardenCanvas.tsx
@@ -12,6 +12,7 @@ interface GardenCanvasProps {
   widthPx?: number;
   heightPx?: number;
   selected?: { x: number; y: number } | null;
+  previewItem?: { img: string; label?: string; w: number; h: number } | null;
   onCellClick?: (x: number, y: number) => void;
   onItemPointerDown?: (e: React.PointerEvent, item: GardenPlacedItem) => void;
   npc?: { x: number; y: number; message?: string } | null;
@@ -29,6 +30,7 @@ export function GardenCanvas({
   widthPx = WIDTH,
   heightPx = HEIGHT,
   selected = null,
+  previewItem = null,
   onCellClick,
   onItemPointerDown,
   npc,
@@ -46,7 +48,7 @@ export function GardenCanvas({
 
   return (
     <div
-      className={`relative overflow-hidden ${className}`}
+      className={`relative overflow-hidden garden-shadow ${className}`}
       style={{ width: w, height: h }}
     >
       <img
@@ -54,7 +56,7 @@ export function GardenCanvas({
         alt="Zen garden map background"
         width={w}
         height={h}
-        className="pixelated garden-shadow"
+        className="pixelated"
         style={{
           width: w,
           height: h,
@@ -75,7 +77,14 @@ export function GardenCanvas({
             const x = i % GARDEN_COLS;
             const y = Math.floor(i / GARDEN_COLS);
             const locked = isTileLocked(x, y);
-            const isSel = selected?.x === x && selected?.y === y;
+            const wSel = previewItem?.w || 1;
+            const hSel = previewItem?.h || 1;
+            const isSel =
+              selected !== null &&
+              x >= selected.x &&
+              x < selected.x + wSel &&
+              y >= selected.y &&
+              y < selected.y + hSel;
             return (
               <div
                 key={i}
@@ -131,14 +140,51 @@ export function GardenCanvas({
           style={{
             left: it.x * TILE_PX,
             top: it.y * TILE_PX,
-            width: TILE_PX,
-            height: TILE_PX,
+            width: (it.w || 1) * TILE_PX,
+            height: (it.h || 1) * TILE_PX,
           }}
           onPointerDown={(e) => onItemPointerDown?.(e, it)}
         >
-          <img src={it.img} alt={it.label || 'Garden item'} width={TILE_PX} height={TILE_PX} style={{ width: TILE_PX, height: TILE_PX, objectFit: 'contain', imageRendering: 'pixelated' as any }} />
+          <img
+            src={it.img}
+            alt={it.label || 'Garden item'}
+            width={(it.w || 1) * TILE_PX}
+            height={(it.h || 1) * TILE_PX}
+            style={{
+              width: (it.w || 1) * TILE_PX,
+              height: (it.h || 1) * TILE_PX,
+              objectFit: 'contain',
+              imageRendering: 'pixelated' as any,
+            }}
+          />
         </div>
       ))}
+
+      {/* Preview item */}
+      {previewItem && selected && (
+        <div
+          className="absolute pointer-events-none opacity-80"
+          style={{
+            left: selected.x * TILE_PX,
+            top: selected.y * TILE_PX,
+            width: previewItem.w * TILE_PX,
+            height: previewItem.h * TILE_PX,
+          }}
+        >
+          <img
+            src={previewItem.img}
+            alt={previewItem.label || 'Preview item'}
+            width={previewItem.w * TILE_PX}
+            height={previewItem.h * TILE_PX}
+            style={{
+              width: previewItem.w * TILE_PX,
+              height: previewItem.h * TILE_PX,
+              objectFit: 'contain',
+              imageRendering: 'pixelated' as any,
+            }}
+          />
+        </div>
+      )}
 
       {/* NPC (Cat) */}
       {npc && (

--- a/src/components/modals/GardenPlacementModal.tsx
+++ b/src/components/modals/GardenPlacementModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { loadProgress, GardenStep } from '@/utils/storageClient';
-import { placeGardenItem } from '@/utils/gardenHelpers';
+import { placeGardenItem, getItemFootprint } from '@/utils/gardenHelpers';
 import { isTileLocked } from '@/utils/gardenMap';
 import GardenCanvas from '@/components/garden/GardenCanvas';
 import { toast } from '@/components/ui/sonner';
@@ -58,17 +58,29 @@ export default function GardenPlacementModal({ open, onClose, token, onPlaced }:
 
   const garden = progress.garden || { cols: 12, rows: 8, placed: [], bg: 'gravel_light.png' };
   const targetToken: GardenStep | undefined = token || progress.pendingToken || (progress.pendingTokens?.find(t => !!t) || undefined);
+  const previewItem = targetToken ? { img: targetToken.img, label: targetToken.label, ...getItemFootprint(targetToken.id) } : null;
 
-  const isFull = (garden.placed?.length || 0) >= garden.cols * garden.rows;
-  const isOccupied = (x: number, y: number) => garden.placed?.some((it) => it.x === x && it.y === y);
+  const totalOccupied = garden.placed.reduce((s, it) => s + (it.w || 1) * (it.h || 1), 0);
+  const isFull = totalOccupied >= garden.cols * garden.rows;
+  const isOccupied = (x: number, y: number, w = 1, h = 1) =>
+    garden.placed?.some(it => {
+      const iw = it.w || 1; const ih = it.h || 1;
+      return x < it.x + iw && x + w > it.x && y < it.y + ih && y + h > it.y;
+    });
 
   const handleCellClick = (x: number, y: number) => {
     if (!targetToken) return;
-    if (isTileLocked(x, y)) {
-      // Ignore clicks on blocked temple tiles
+    const { w, h } = getItemFootprint(targetToken.id);
+    if (x + w > garden.cols || y + h > garden.rows) {
+      toast('Too close to the edge');
       return;
     }
-    if (isOccupied(x, y)) {
+    for (let dx = 0; dx < w; dx++) {
+      for (let dy = 0; dy < h; dy++) {
+        if (isTileLocked(x + dx, y + dy)) return;
+      }
+    }
+    if (isOccupied(x, y, w, h)) {
       toast('That spot is taken');
       return;
     }
@@ -85,6 +97,7 @@ export default function GardenPlacementModal({ open, onClose, token, onPlaced }:
         setPlacing(false);
         if (r.reason === 'occupied') toast('That spot is taken');
         else if (r.reason === 'locked') toast('You cannot place on temple tiles');
+        else if (r.reason === 'out_of_bounds') toast('Too close to the edge');
         else if (r.reason === 'not_owned') toast('This item has already been placed');
         else toast('Could not place item');
         return;
@@ -127,6 +140,7 @@ export default function GardenPlacementModal({ open, onClose, token, onPlaced }:
                 showGrid
                 showLockedOverlay
                 selected={selected}
+                previewItem={previewItem}
                 onCellClick={handleCellClick}
                 className="select-none"
                 npc={null}

--- a/src/index.css
+++ b/src/index.css
@@ -204,13 +204,6 @@ body.dark .shopify-buy__product__price {
   .path-card { flex-basis: 88px; height: 88px; }
 }
 
-/* Custom animations */
-@keyframes legendary-glow {
-  0% { box-shadow: 0 0 0 hsl(var(--legendary) / 0); }
-  50% { box-shadow: 0 0 28px hsl(var(--legendary) / 0.45), 0 0 64px hsl(var(--legendary) / 0.25); }
-  100% { box-shadow: 0 0 0 hsl(var(--legendary) / 0); }
-}
-
 @layer utilities {
   .pixelated {
     image-rendering: pixelated;
@@ -243,9 +236,20 @@ body.dark .shopify-buy__product__price {
   .garden-shadow {
     filter: drop-shadow(0 16px 28px hsl(var(--ring) / 0.25)) drop-shadow(0 4px 8px hsl(var(--ring) / 0.2));
   }
+  @keyframes legendary-glow {
+    0%, 100% {
+      box-shadow: 0 0 24px hsl(var(--legendary) / 0.4),
+                  0 0 56px hsl(var(--legendary) / 0.2);
+    }
+    50% {
+      box-shadow: 0 0 32px hsl(var(--legendary) / 0.6),
+                  0 0 72px hsl(var(--legendary) / 0.3);
+    }
+  }
+
   .legendary-ring {
     border-radius: 12px;
-    animation: legendary-glow 2.2s ease-in-out infinite;
+    animation: legendary-glow 2s ease-in-out infinite;
   }
 }
 

--- a/src/pages/Garden.tsx
+++ b/src/pages/Garden.tsx
@@ -109,15 +109,12 @@ export default function Garden() {
     const relY = Math.min(Math.max(e.clientY - stageRect.top, 0), stageRect.height);
     const gx = Math.floor(relX / (cellW * scale));
     const gy = Math.floor(relY / (cellH * scale));
-
-    // Check vacancy
-    const occupied = garden.placed.some(it => it.x === gx && it.y === gy && it.id !== id);
-    if (occupied) {
-      alert('That spot is taken.');
-      setProgress(loadProgress());
-      return;
+    const res = moveGardenItem(id, gx, gy);
+    if (!res.ok) {
+      if (res.reason === 'occupied') alert('That spot is taken.');
+      else if (res.reason === 'locked') alert('You cannot place on temple tiles.');
+      else if (res.reason === 'out_of_bounds') alert('Out of bounds.');
     }
-    moveGardenItem(id, gx, gy);
     setProgress(loadProgress());
   };
 

--- a/src/pages/ZenPath.tsx
+++ b/src/pages/ZenPath.tsx
@@ -48,6 +48,7 @@ export default function ZenPath() {
           {Array.from({ length: progress.pathLength }).map((_, index) => {
             const step = progress.currentPath[index];
             const isEmpty = !step;
+            const isLegendary = (step as any)?.rarity === 'legendary';
             
             return (
               <div
@@ -60,10 +61,10 @@ export default function ZenPath() {
               >
                   {step ? (
                     <>
-                      <img 
-                        src={step.img} 
+                      <img
+                        src={step.img}
                         alt={step.label}
-                        className="w-12 h-12 object-contain mb-2"
+                        className={`w-12 h-12 object-contain mb-2 ${isLegendary ? 'legendary-ring p-1' : ''}`}
                         onError={(e) => {
                           // Fallback for missing images
                           e.currentTarget.style.display = 'none';

--- a/src/utils/storageClient.ts
+++ b/src/utils/storageClient.ts
@@ -38,6 +38,8 @@ export type GardenPlacedItem = {
   y: number; // 0-based row
   rotation: 0 | 90 | 180 | 270;
   placedAt: string;
+  w?: number;
+  h?: number;
 };
 
 export type GardenState = {


### PR DESCRIPTION
## Summary
- soften garden background with drop shadow
- show animated legendary glow in path preview and reward reveal
- treat specific garden items as 2x2 tiles with updated placement, movement, and rendering
- preview garden items with their artwork before confirming placement

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 96 problems, 87 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689af70a4930832c94a8bdac59141a84