### PR TITLE
Fix fog reveal and step tracking

### DIFF
--- a/src/hooks/useMonkMovement.test.ts
+++ b/src/hooks/useMonkMovement.test.ts
@@ -1,0 +1,22 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useMonkMovement } from './useMonkMovement';
+import { makeFog, isRevealed } from '@/features/fog/useFog';
+import { ProgressData } from '@/utils/storageClient';
+
+describe('useMonkMovement', () => {
+  it('updates position, fog, and steps', () => {
+    const fog = makeFog(4, 4);
+    const progress: ProgressData = {
+      journey: { tx: 0, ty: 0, pathId: 'default', step: 0 },
+      pendingSteps: 3,
+      fog: { cols: 4, rows: 4, revealed: Array(16).fill(0) }
+    };
+    const { result } = renderHook(() => useMonkMovement());
+    result.current(progress, fog, 2, 0, 2);
+    expect(progress.journey.tx).toBe(2);
+    expect(progress.journey.step).toBe(2);
+    expect(progress.pendingSteps).toBe(1);
+    expect(isRevealed(2, 0, fog)).toBe(true);
+  });
+});

--- a/src/hooks/useMonkMovement.ts
+++ b/src/hooks/useMonkMovement.ts
@@ -1,25 +1,28 @@
 import { useCallback } from 'react';
 import { ProgressData } from '@/utils/storageClient';
-import { revealRadius, makeFog, fromSavedFog } from '@/features/fog/useFog';
-import { GARDEN_COLS, GARDEN_ROWS } from '@/utils/gardenMap';
+import { revealRadius, Fog } from '@/features/fog/useFog';
 
 export const useMonkMovement = () => {
   return useCallback(
-    (progress: ProgressData, targetTx: number, targetTy: number) => {
-      const journey = progress.journey || { tx: 0, ty: 0, pathId: 'default', step: 0 };
-      const fog = progress.fog
-        ? fromSavedFog(progress.fog)
-        : makeFog(GARDEN_COLS, GARDEN_ROWS);
+    (
+      progress: ProgressData,
+      fog: Fog,
+      targetTx: number,
+      targetTy: number,
+      steps: number
+    ) => {
+      const journey =
+        progress.journey || { tx: 0, ty: 0, pathId: 'default', step: 0 };
 
       // Calculate movement direction for sprite facing
       const deltaX = targetTx - journey.tx;
       const deltaY = targetTy - journey.ty;
-      
+
       // Move monk to target position
       journey.tx = targetTx;
       journey.ty = targetTy;
-      journey.step += 1;
-      
+      journey.step += steps;
+
       // Set facing direction
       if (deltaX > 0) journey.facing = 'right';
       else if (deltaX < 0) journey.facing = 'left';
@@ -30,8 +33,15 @@ export const useMonkMovement = () => {
 
       // Update progress
       progress.journey = journey;
-      progress.fog = { cols: fog.cols, rows: fog.rows, revealed: Array.from(fog.revealed) };
-      progress.pendingSteps = Math.max(0, (progress.pendingSteps || 0) - 1);
+      progress.fog = {
+        cols: fog.cols,
+        rows: fog.rows,
+        revealed: Array.from(fog.revealed),
+      };
+      progress.pendingSteps = Math.max(
+        0,
+        (progress.pendingSteps || 0) - steps
+      );
     },
     []
   );

--- a/src/pages/WorldMap.test.tsx
+++ b/src/pages/WorldMap.test.tsx
@@ -9,16 +9,16 @@ vi.mock('@/utils/storageClient', () => ({
   loadProgress: () => ({
     journey: { tx: 0, ty: 0, pathId: 'default', step: 0 },
     fog: { cols: 4, rows: 4, revealed: Array(16).fill(0) },
-    pendingSteps: 1,
+    pendingSteps: 2,
     camera: { x: 0, y: 0, zoom: 1 }
   }),
   saveProgress: vi.fn()
 }));
 
 vi.mock('@/components/modals/PostSessionMovementModal', () => ({
-  default: ({ isOpen, onMoveToTile }: { isOpen: boolean; onMoveToTile: (tx: number, ty: number) => void }) => {
+  default: ({ isOpen, onMoveToTile }: { isOpen: boolean; onMoveToTile: (tx: number, ty: number, steps: number) => void }) => {
     if (isOpen) {
-      onMoveToTile(1, 1);
+      onMoveToTile(1, 1, 2);
     }
     return null;
   }
@@ -41,6 +41,7 @@ describe('WorldMap integration', () => {
     expect(updated.journey.tx).toBe(1);
     expect(updated.journey.ty).toBe(1);
     expect(updated.pendingSteps).toBe(0);
+    expect(updated.journey.step).toBe(2);
     expect(updated.fog.revealed[1 + 1 * updated.fog.cols]).toBe(1);
   });
 });

--- a/src/pages/WorldMap.tsx
+++ b/src/pages/WorldMap.tsx
@@ -4,7 +4,7 @@ import { loadProgress, saveProgress } from '@/utils/storageClient';
 import { monkGif } from '@/assets/monk';
 import { Camera, Grid, tileToWorld, getVisibleTileRect, tileCenterToWorld } from '@/utils/grid';
 import { GARDEN_COLS, GARDEN_ROWS, TILE_PX } from '@/utils/gardenMap';
-import { makeFog, fromSavedFog, isRevealed, revealRadius, initializeFogAroundMonk } from '@/features/fog/useFog';
+import { makeFog, fromSavedFog, isRevealed, initializeFogAroundMonk } from '@/features/fog/useFog';
 import StepPanel from '@/components/world/StepPanel';
 import PostSessionMovementModal from '@/components/modals/PostSessionMovementModal';
 import { useMonkMovement } from '@/hooks/useMonkMovement';
@@ -121,9 +121,9 @@ export default function WorldMap() {
     ctx.globalCompositeOperation = 'source-over';
   }, [camera, fog, progress, grid]);
 
-  const handleMoveToTile = (tx: number, ty: number) => {
+  const handleMoveToTile = (tx: number, ty: number, steps: number) => {
     const updatedProgress = { ...progress };
-    moveMonk(updatedProgress, tx, ty);
+    moveMonk(updatedProgress, fog, tx, ty, steps);
     saveProgress(updatedProgress);
     setProgress(updatedProgress);
     setShowMovementModal(false);


### PR DESCRIPTION
## Summary
- ensure fog-of-war reveals around monk when moving
- deduct the correct number of steps on multi-tile moves
- add monk movement unit test

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689cb47cfb00832cbeb9ad0237fa5c52